### PR TITLE
Remove invalid arguments from `cargo ndk`

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -22,9 +22,9 @@ if (($clean.IsPresent) -or (-not (Test-Path -Path "build")))
 # build the rust code
 cd ./tracks_rs_link
 if ($release.IsPresent) {
-    cargo ndk --bindgen --no-strip -t arm64-v8a -o build build --release
+    cargo ndk --no-strip -t arm64-v8a -o build build --release
 } else {
-    cargo ndk --bindgen --no-strip -t arm64-v8a -o build build
+    cargo ndk --no-strip -t arm64-v8a -o build build
 }
 cd ..
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -22,9 +22,9 @@ if (($clean.IsPresent) -or (-not (Test-Path -Path "build")))
 # build the rust code
 cd ./tracks_rs_link
 if ($release.IsPresent) {
-    cargo ndk --no-strip -t arm64-v8a -o build build --release
+    cargo ndk -t arm64-v8a -o build build --release
 } else {
-    cargo ndk --no-strip -t arm64-v8a -o build build
+    cargo ndk -t arm64-v8a -o build build
 }
 cd ..
 


### PR DESCRIPTION
- `--bindgen` was deprecated in https://github.com/bbqsrc/cargo-ndk/commit/de4dcba8e3d545b87b55bd7c37ff3098717cec39
- Stripping was removed in https://github.com/bbqsrc/cargo-ndk/commit/b91ae0dfcf1f85d774b749185c40f1d003592792